### PR TITLE
Fixed an empty response. Because of nulled session it doesn't validat…

### DIFF
--- a/index.php
+++ b/index.php
@@ -106,7 +106,7 @@ try{
     } else {
         $response = json_encode([
             'version' => '1.0',
-            'session' => [],
+            'session' => 'Error',
             'response' => [
                 'text' => 'Отсутствуют данные',
                 'tts' =>  'Отсутствуют данные'


### PR DESCRIPTION
…e in Yandex Dialogs Form

When this example placed on a server, dialogs.yandex.ru->Settings->Webhook URL don't take it as valid voiceskill, because it returns null session. So I placed a placeholder 'Error' to prevent this behaviour, so a voiceskill from the example above could be validated (right now it doesn't).
Also it closes https://github.com/jeyroik/php-yandex-alisa-simple/issues/1